### PR TITLE
Fix code scanning alert no. 4: Incorrect conversion between integer types

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"math"
 )
 
 func main() {
@@ -134,7 +135,13 @@ func main() {
 	// If the input string represents a number that is too large for the target integer type, it can cause unexpected behavior or security issues.
 	// Best practice is to use appropriate integer types with sufficient range and perform proper error handling and input validation.
 	val := resp.Request.URL.Query().Get("val")
-	num, _ := strconv.Atoi(val)
+	num, err := strconv.Atoi(val)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if num < math.MinInt16 || num > math.MaxInt16 {
+		log.Fatal("value out of range for int16")
+	}
 	var intVal int16 = int16(num)
 	fmt.Println(intVal)
 


### PR DESCRIPTION
Fixes [https://github.com/shunmugadigialert/Go1Ai/security/code-scanning/4](https://github.com/shunmugadigialert/Go1Ai/security/code-scanning/4)

To fix the problem, we need to ensure that the integer value parsed from the string is within the valid range for `int16` before performing the conversion. This can be done by checking if the parsed integer is within the bounds of `math.MinInt16` and `math.MaxInt16`. If the value is out of bounds, we should handle it appropriately, such as by returning a default value or an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
