### PR TITLE
Fix code scanning alert no. 1: Insecure TLS configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func main() {
 	// Older TLS versions have weaknesses that can be exploited by attackers to compromise the security of the connection.
 	// Best practice is to use a minimum TLS version of 1.2 or higher and disable support for older, insecure versions.
 	config := &tls.Config{
-		MinVersion: tls.VersionSSL30,
+		MinVersion: tls.VersionTLS12,
 	}
 	_, _ = tls.Dial("tcp", "example.com:443", config)
 


### PR DESCRIPTION
Fixes [https://github.com/shunmugadigialert/Go1Ai/security/code-scanning/1](https://github.com/shunmugadigialert/Go1Ai/security/code-scanning/1)

To fix the problem, we need to update the TLS configuration to use a secure version of the protocol. Specifically, we should set the `MinVersion` to `tls.VersionTLS12` to ensure that only TLS 1.2 and higher versions are used. This change will enhance the security of the communication by preventing the use of older, insecure versions of the protocol.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
